### PR TITLE
Change jcenter to mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ def computeVersionName() {
 }
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
As of February 1, 2021, JCenter will go offline,

It is required to update to RN 0.65 and Change jcenter to mavenCentral

https://github.com/react-native-community/discussions-and-proposals/issues/331